### PR TITLE
Fix first line of package header

### DIFF
--- a/perl-completion.el
+++ b/perl-completion.el
@@ -1,4 +1,4 @@
-;;; perl-completion.el - minor mode provides useful features for editing perl codes
+;;; perl-completion.el --- minor mode provides useful features for editing perl codes
 
 ;; Copyright (c) 2009 by KAYAC Inc.
 


### PR DESCRIPTION
"[Conventional Headers for Emacs Libraries](https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html#Library-Headers)" suggests that the first line of a package should be of the form

```
;;; filename --- description
```

If the header is of a different format, the package's description may not be found. As an example, MELPA currently shows "No description available" for this package.
